### PR TITLE
Save WiFi to EEPROM

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@ Functional highlights:
 
 
 To use:
-* Change the configurables based on your network and wiring to LEDs.
-* Flash to the board and load the Bootstrap file from /data into SPIFFS (it just serves a reference if it's connected to an AP, but serves the CSS from SPIFFS if it's broadcasting its own)
-* When it connects, either use the Serial readout or it flashes LEDs (red = 100s place, yellow = 10s, green = 1s) to give you the last octet of the IP. All LEDs on = SoftAP mode, IP=192.168.4.1
-* Pull the page up in a browser (tested in Chrome & Safari mobile)
+* Change the configurables based on your wiring to LEDs. Compile & upload to the board
+* On first load, it will fail to connect to a wifi network and will broadcast its own ("LightClock" SSID, unless you changed it). Connect to that network and load http://192.168.4.1
+* You can configure it for your WiFi SSID and PSK on that page.
+* When it connects, either use the Serial readout or it flashes LEDs (red = 100s place, yellow = 10s, green = 1s) to give you the last octet of the IP. All LEDs on = SoftAP mode
+* Pull the page up (http://<IP of device>) in a browser - tested in Chrome & Safari mobile
 * If needed, you can change the timezone offset or manually reset the clock (if it's connected to a network without NTP access, like its own) at the bottom
 * Set the alarm by entering a 24hr time, no seconds ("6:00") in the alarm box, and mash the button
 * Use the color buttons for overrides. Any color button disables the alarm functionality

--- a/mainpage.h
+++ b/mainpage.h
@@ -95,6 +95,15 @@ function dumpTS() {
 </div>
 </form>
 
+<form method="post" action="/wifi">
+<div class="well text-center">
+<h3>WiFi Configuration</h3>
+<p><input type="text" id="ssid" name="ssid" value="@@SSID@@" placeholder="SSID"></p>
+<p><input type="password" id="psk" name="psk"></p>
+<p><input type="submit" name="m" value="Connect" class="btn btn-med btn-default"></p>
+</div>
+</form>
+
 </body>
 </html>
 )=====";

--- a/persistence.ino
+++ b/persistence.ino
@@ -1,0 +1,28 @@
+#define SSID_LENGTH 32
+#define PSK_LENGTH 64
+
+#include <EEPROM.h>
+
+char ee_ssid[SSID_LENGTH];
+char ee_psk[PSK_LENGTH];
+char * eeprom_psk() { return ee_psk; }
+char * eeprom_ssid() { return ee_ssid; }
+void eeprom_load_wifi() {
+  EEPROM.begin(512);
+  for (int i = 0; i < SSID_LENGTH; ++i) ee_ssid[i] = char(EEPROM.read(i));
+  Serial.print("SSID (EEPROM): ");
+  Serial.println(String(ee_ssid));
+  for (int i = 0; i < PSK_LENGTH; ++i) ee_psk[i] = char(EEPROM.read(SSID_LENGTH+ i));
+  Serial.print("PSK (EEPROM): ");
+  Serial.println(String(ee_psk));  
+}
+void eeprom_save_wifi(String in_ssid, String in_psk) {
+  EEPROM.begin(512);
+  if (in_ssid.length() > 0 && in_ssid.length() > 0) {
+    for (int i = 0; i < (SSID_LENGTH+PSK_LENGTH); ++i) EEPROM.write(i, 0);
+    for (int i = 0; i < in_ssid.length(); ++i) EEPROM.write(i, in_ssid[i]);
+    for (int i = 0; i < in_psk.length(); ++i) EEPROM.write(SSID_LENGTH+i, in_psk[i]);
+    EEPROM.commit();
+  }
+}
+

--- a/wifi.ino
+++ b/wifi.ino
@@ -1,5 +1,37 @@
 #define FLASH_LENGTH 500
 #define FLASH_DELAY 1000
+
+void setupWiFiAP() {
+  WiFi.softAP(WIFI_AP_SSID);
+  Serial.print("AP Mode (");
+  Serial.print(String(WIFI_AP_SSID));
+  Serial.print(") IP: ");
+  Serial.println(WiFi.softAPIP());
+  setcolor(MODE_ON);
+}
+void setupWiFi() {
+  WiFi.mode(WIFI_STA);
+  eeprom_load_wifi();
+  WiFi.begin(eeprom_ssid(), eeprom_psk());
+  Serial.print("Connecting to ");
+  Serial.print(eeprom_ssid());
+  int clicks = 0;
+  while (WiFi.status() != WL_CONNECTED && clicks<20) {
+    clicks++;
+    delay(500);
+    Serial.print(".");
+  }
+  if (WiFi.status() == WL_CONNECTED) {
+    Serial.print("\nConnected. IP: ");
+    Serial.println(WiFi.localIP());
+    FlashLastOctet(WiFi.localIP());
+    setupTime();
+  } else { //Couldn't connect to WIFI_SSID, instantiating local AP
+    Serial.println();
+    setupWiFiAP();
+  }
+}
+
 void FlashLastOctet(IPAddress IP) {
   int lastoctet = IP[3];
   Serial.print("Flashing IP: ");
@@ -32,20 +64,4 @@ void FlashLastOctet(IPAddress IP) {
     setcolor(MODE_OFF);
     delay(FLASH_LENGTH);
   }
-}
-String getValue(String data, char separator, int index)
-{
-  int found = 0;
-  int strIndex[] = {0, -1};
-  int maxIndex = data.length()-1;
-
-  for(int i=0; i<=maxIndex && found<=index; i++){
-    if(data.charAt(i)==separator || i==maxIndex){
-        found++;
-        strIndex[0] = strIndex[1]+1;
-        strIndex[1] = (i == maxIndex) ? i+1 : i;
-    }
-  }
-
-  return found>index ? data.substring(strIndex[0], strIndex[1]) : "";
 }


### PR DESCRIPTION
Refactored WiFi connections into separate file and built EEPROM storage for SSID and PSK. This also creates a box in the UI that allows you to update the wifi network information that gets stored in EEPROM. If it can't connect to that network, it will still fall back to broadcasting its own.
 
Fixes #1 